### PR TITLE
Set git user identity to fix do_patch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,3 +43,6 @@ RUN apt-get update && \
 
 # Switch to regular user for security reasons
 USER buildbot
+
+RUN git config --global user.email "builder@forestscribe.local" && \
+    git config --global user.name "Forestscribe Builder"


### PR DESCRIPTION
do_patch is not working if git user identity is not set, see http://tlsisbld125l.tl.intel.com:30030/#/builders/4/builds/188/steps/2/logs/stdio

I tested a to create a git repo and commit something in it in the docker image and it works, not tested to do a bitbake build with do_patch ...